### PR TITLE
Fixed the Exception when Loader hide or disposed

### DIFF
--- a/lib/animation/four_balls.dart
+++ b/lib/animation/four_balls.dart
@@ -14,6 +14,12 @@ class FourBallsState extends State<FourBalls> with TickerProviderStateMixin {
   Animation _animation1, _animation2;
 
   @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
   void initState() {
     super.initState();
     var mult = 0.5;

--- a/lib/animation/pulse.dart
+++ b/lib/animation/pulse.dart
@@ -26,6 +26,17 @@ class PulseLoaderState extends State<PulseLoader>
   Animation _scaleAnimation1, _scaleAnimation2, _scaleAnimation3;
 
   @override
+  void dispose() {
+    _controller1.dispose();
+    _controller2.dispose();
+    _controller3.dispose();
+    _alphaController1.dispose();
+    _alphaController2.dispose();
+    _alphaController3.dispose();
+    super.dispose();
+  }
+
+  @override
   void initState() {
     super.initState();
 

--- a/lib/animation/zig_zag.dart
+++ b/lib/animation/zig_zag.dart
@@ -17,6 +17,12 @@ class ZigZagState extends State<ZigZag> with TickerProviderStateMixin {
   Animation _animation1;
 
   @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
   void initState() {
     super.initState();
 


### PR DESCRIPTION
Fixes #1 

When the Loader is disposed of, the animation is not disposed of and causes exceptions in the terminal.
